### PR TITLE
Add support for Onfleet Containers

### DIFF
--- a/onfleet/models.py
+++ b/onfleet/models.py
@@ -97,8 +97,8 @@ class Task(object):
 
     def __init__(self, destination, recipients, notes=None, state=None,
             id=None, created_on=None, updated_on=None, merchant=None,
-            executor=None, pickup_task=False, tracking_url=None,
-            worker=None, dependencies=None, complete_after=None,
+            executor=None, pickup_task=False, tracking_url=None, worker=None,
+            dependencies=None, container=None, complete_after=None,
             complete_before=None, delay_time=None):
         self.id = id
         self.created_on = created_on
@@ -113,6 +113,7 @@ class Task(object):
         self.complete_after = complete_after
         self.complete_before = complete_before
         self.dependencies = dependencies
+        self.container = container
         self.worker = worker
         self.delay_time = delay_time
 
@@ -144,6 +145,9 @@ class Task(object):
 
         if obj['delayTime']:
             task.delay_time = obj['delayTime']
+
+        if obj['container']:
+            task.container = obj['container']
 
         return task
 
@@ -280,4 +284,3 @@ class Worker(object):
             worker.delay_time = timedelta(seconds=obj['delayTime'])
 
         return worker
-

--- a/onfleet/models.py
+++ b/onfleet/models.py
@@ -146,7 +146,7 @@ class Task(object):
         if obj['delayTime']:
             task.delay_time = obj['delayTime']
 
-        if obj['container']:
+        if 'container' in obj:
             task.container = obj['container']
 
         return task

--- a/onfleet/onfleet.py
+++ b/onfleet/onfleet.py
@@ -103,6 +103,7 @@ class ComplexEncoder(json.JSONEncoder):
                 'dependencies': 'dependencies',
                 'complete_after': 'completeAfter',
                 'complete_before': 'completeBefore',
+                'container': 'container',
             }
         elif isinstance(obj, models.Recipient):
             payload = {
@@ -189,7 +190,9 @@ class OnfleetCall(object):
             if component in self.components:
                 parse_as = parser
 
-        if method.lower() != 'delete':
+        if response.text:
+            # If the response is not falsy.
+
             json_response = response.json()
 
             if 'code' in json_response:

--- a/onfleet/onfleet.py
+++ b/onfleet/onfleet.py
@@ -186,9 +186,11 @@ class OnfleetCall(object):
         }
 
         parse_as = None
+        component_name = ''
         for component, parser in parse_dictionary.iteritems():
             if component in self.components:
                 parse_as = parser
+                component_name = component
 
         if response.text:
             # If the response is not falsy.
@@ -249,6 +251,13 @@ class OnfleetCall(object):
             if parse_response and parse_as is not None:
                 if isinstance(json_response, list):
                     return map(parse_as.parse, json_response)
+                # Handle pagination case, where Onfleet supplies lastId.
+                elif 'lastId' in json_response:
+                    return {
+                        'lastId': json_response['lastId'],
+                        'results': map(parse_as.parse,
+                            json_response[component_name]),
+                    }
                 else:
                     return parse_as.parse(json_response)
             else:


### PR DESCRIPTION
Adds support to python-onfleet for: http://docs.onfleet.com/docs/containers

With these changes, we can parse responses from container calls (even though nothing is returned).

And example call using this from chewse/chewse would include: 

```
onfleet_api.containers.workers[self.onfleet_worker_id](
    {'tasks': [-1] + task_ids},
    method='PUT'
)
```
