### PR TITLE
Support response type for tasks/all path

### DIFF
--- a/onfleet/onfleet.py
+++ b/onfleet/onfleet.py
@@ -258,6 +258,11 @@ class OnfleetCall(object):
                         'results': map(parse_as.parse,
                             json_response[component_name]),
                     }
+                elif 'all' in self.components:
+                    return {
+                        'results': map(parse_as.parse,
+                            json_response[component_name]),
+                    }
                 else:
                     return parse_as.parse(json_response)
             else:


### PR DESCRIPTION
This adds the ability to support Onfleet's divergent response type whenever the `x/all` path is hit. Usually they return a list of objects (e.g. when hitting `/tasks`), but when hitting `/tasks/all` they return an object with a key of `tasks` and value of a list of objects.

Example response from a `GET` against `https://onfleet.com/api/v2/tasks`:
```json
[
  {
    "id": "abcdefghi123456789",
    "timeCreated": 1477000000000,
    "timeLastModified": 1477000000000,
    "organization": "abcdefghi123456789",
    "shortId": "abcd0000",
    "trackingURL": "https://www.com",
    ...
  }
]
```

Compared to a `GET` against `https://onfleet.com/api/v2/tasks/all?from=__epoch_ts_in_ms__`
```json
{
  "tasks": [
    {
      "id": "abcdefghi123456789",
      "timeCreated": 1477000000000,
      "timeLastModified": 1477000000000,
      "organization": "abcdefghi123456789",
      "shortId": "abcd0000",
      "trackingURL": "https://www.com",
      ...
    }
  ]
}
```

Note that a `GET` against `https://onfleet.com/api/v2/tasks/all?from=__epoch_ts_in_ms__` WITH multiple pages includes a `lastId` key, as the following shows:
```json
{
  "lastId": "abcdefghi123456789",
  "tasks": [
    {
      "id": "abcdefghi123456789",
      "timeCreated": 1477000000000,
      "timeLastModified": 1477000000000,
      "organization": "abcdefghi123456789",
      "shortId": "abcd0000",
      "trackingURL": "https://www.com",
      ...
    }
  ]
}
```