### PR TITLE
Make recipient notes response field optional

### DIFF
--- a/onfleet/models.py
+++ b/onfleet/models.py
@@ -83,8 +83,9 @@ class Recipient(object):
             updated_on=obj['timeLastModified'],
             name=obj['name'],
             phone=obj['phone'],
-            notes=obj['notes']
         )
+        if 'notes' in obj:
+            recipient.notes = obj['notes']
 
         return recipient
 


### PR DESCRIPTION
Stemming from our findings about Onfleet in chewse/chewse/issues/2337, we need to make the `recipient`'s `notes` field option when parsing responses, given that the field may sometimes be absent entirely.

This will fix issue chewse/chewse/issues/2341